### PR TITLE
Modified REGISTER to provide port number in URI.

### DIFF
--- a/SIP/SIPEngine.cpp
+++ b/SIP/SIPEngine.cpp
@@ -122,6 +122,7 @@ ostream& SIP::operator<<(ostream& os, SIPState s)
 
 SIPEngine::SIPEngine(const char* proxy, const char* IMSI)
 	:mCSeq(random()%1000),
+	mProxy(proxy),
 	mMyToFromHeader(NULL), mRemoteToFromHeader(NULL),
 	mCallIDHeader(NULL),
 	mSIPPort(gConfig.getNum("SIP.Local.Port")),
@@ -316,6 +317,17 @@ void SIPEngine::writePrivateHeaders(osip_message_t *msg, const GSM::LogicalChann
 
 bool SIPEngine::Register( Method wMethod )
 {
+	std::string mRegisterBranch;
+	char tmp[50];
+	make_branch(tmp);
+	mRegisterBranch = tmp;
+
+	mViaBranch = tmp;
+
+	std::string mRegisterURI;
+	mRegisterURI = "sip:";
+	mRegisterURI += mProxy;
+
 	LOG(INFO) << "user " << mSIPUsername << " state " << mState << " " << wMethod << " callID " << mCallID;
 
 	// Before start, need to add mCallID
@@ -333,15 +345,15 @@ bool SIPEngine::Register( Method wMethod )
 		reg = sip_register( mSIPUsername.c_str(), 
 			60*gConfig.getNum("SIP.RegistrationPeriod"),
 			mSIPPort, mSIPIP.c_str(), 
-			mProxyIP.c_str(), mMyTag.c_str(), 
-			mViaBranch.c_str(), mCallID.c_str(), mCSeq
+			mRegisterURI.c_str(), mMyTag.c_str(),
+			mRegisterBranch.c_str(), mCallID.c_str(), mCSeq
 		); 
 	} else if (wMethod == SIPUnregister ) {
 		reg = sip_register( mSIPUsername.c_str(), 
 			0,
 			mSIPPort, mSIPIP.c_str(), 
-			mProxyIP.c_str(), mMyTag.c_str(), 
-			mViaBranch.c_str(), mCallID.c_str(), mCSeq
+			mRegisterURI.c_str(), mMyTag.c_str(),
+			mRegisterBranch.c_str(), mCallID.c_str(), mCSeq
 		);
 	} else { assert(0); }
 

--- a/SIP/SIPEngine.cpp
+++ b/SIP/SIPEngine.cpp
@@ -317,16 +317,16 @@ void SIPEngine::writePrivateHeaders(osip_message_t *msg, const GSM::LogicalChann
 
 bool SIPEngine::Register( Method wMethod )
 {
-	std::string mRegisterBranch;
+	std::string RegisterBranch;
 	char tmp[50];
 	make_branch(tmp);
-	mRegisterBranch = tmp;
+	RegisterBranch = tmp;
 
 	mViaBranch = tmp;
 
-	std::string mRegisterURI;
-	mRegisterURI = "sip:";
-	mRegisterURI += mProxy;
+	std::string RegisterURI;
+	RegisterURI = "sip:";
+	RegisterURI += mProxy;
 
 	LOG(INFO) << "user " << mSIPUsername << " state " << mState << " " << wMethod << " callID " << mCallID;
 
@@ -345,15 +345,15 @@ bool SIPEngine::Register( Method wMethod )
 		reg = sip_register( mSIPUsername.c_str(), 
 			60*gConfig.getNum("SIP.RegistrationPeriod"),
 			mSIPPort, mSIPIP.c_str(), 
-			mRegisterURI.c_str(), mMyTag.c_str(),
-			mRegisterBranch.c_str(), mCallID.c_str(), mCSeq
+			RegisterURI.c_str(), mMyTag.c_str(),
+			RegisterBranch.c_str(), mCallID.c_str(), mCSeq
 		); 
 	} else if (wMethod == SIPUnregister ) {
 		reg = sip_register( mSIPUsername.c_str(), 
 			0,
 			mSIPPort, mSIPIP.c_str(), 
-			mRegisterURI.c_str(), mMyTag.c_str(),
-			mRegisterBranch.c_str(), mCallID.c_str(), mCSeq
+			RegisterURI.c_str(), mMyTag.c_str(),
+			RegisterBranch.c_str(), mCallID.c_str(), mCSeq
 		);
 	} else { assert(0); }
 

--- a/SIP/SIPEngine.h
+++ b/SIP/SIPEngine.h
@@ -101,7 +101,7 @@ private:
 	//@{
 	unsigned mSIPPort;			///< our local SIP port
 	std::string mSIPIP;			///< our SIP IP address as seen by the proxy
-	std::string mProxy;
+	std::string mProxy;			///< SIP Proxy as host:port
 	std::string mProxyIP;			///< IP address of the SIP proxy
 	unsigned mProxyPort;			///< UDP port number of the SIP proxy
 	struct ::sockaddr_in mProxyAddr;	///< the ready-to-use UDP address

--- a/SIP/SIPEngine.h
+++ b/SIP/SIPEngine.h
@@ -101,6 +101,7 @@ private:
 	//@{
 	unsigned mSIPPort;			///< our local SIP port
 	std::string mSIPIP;			///< our SIP IP address as seen by the proxy
+	std::string mProxy;
 	std::string mProxyIP;			///< IP address of the SIP proxy
 	unsigned mProxyPort;			///< UDP port number of the SIP proxy
 	struct ::sockaddr_in mProxyAddr;	///< the ready-to-use UDP address

--- a/SIP/SIPMessage.cpp
+++ b/SIP/SIPMessage.cpp
@@ -170,9 +170,9 @@ int openbts_message_set_rr(osip_message_t *response, osip_message_t *orig)
 	return MSG_NO_ERROR;
 }
 
-osip_message_t * SIP::sip_register( const char * sip_username, short timeout, short wlocal_port, const char * local_ip, const char * proxy_ip, const char * from_tag, const char * via_branch, const char * call_id, int cseq) {
+osip_message_t * SIP::sip_register( const char * sip_username, short timeout, short wlocal_port, const char * local_ip, const char * register_uri, const char * from_tag, const char * via_branch, const char * call_id, int cseq) {
 
- 	char local_port[10];
+	char local_port[10];
 	sprintf(local_port,"%i",wlocal_port);	
 	
 	// Message URI
@@ -183,9 +183,11 @@ osip_message_t * SIP::sip_register( const char * sip_username, short timeout, sh
 	request->sip_method = strdup("REGISTER");
 	osip_message_set_version(request, strdup("SIP/2.0"));	
 	osip_uri_init(&request->req_uri);
-	osip_uri_set_host(request->req_uri, strdup(proxy_ip));
+	osip_uri_parse(request->req_uri, register_uri);
 
-	
+	char* register_host = osip_uri_get_host(request->req_uri);
+	char* register_port = osip_uri_get_port(request->req_uri);
+
 	// VIA
 	osip_via_t * via;
 	osip_via_init(&via);
@@ -212,14 +214,16 @@ osip_message_t * SIP::sip_register( const char * sip_username, short timeout, sh
 	// FROM TAG
 	osip_from_set_tag(request->from, strdup(from_tag));
 	osip_uri_init(&request->from->url);
-	osip_uri_set_host(request->from->url, strdup(proxy_ip));
+	osip_uri_set_host(request->from->url, strdup(register_host));
+	osip_uri_set_port(request->from->url, strdup(register_port));
 	osip_uri_set_username(request->from->url, strdup(sip_username));
 
 	// TO
 	osip_to_init(&request->to);
 	osip_to_set_displayname(request->to, strdup(sip_username));
 	osip_uri_init(&request->to->url);
-	osip_uri_set_host(request->to->url, strdup(proxy_ip));
+	osip_uri_set_host(request->to->url, strdup(register_host));
+	osip_uri_set_port(request->to->url, strdup(register_port));
 	osip_uri_set_username(request->to->url, strdup(sip_username));
 	
 	// CALL ID


### PR DESCRIPTION
Proper REGISTER URI must match host and port of the registration server.

This change allows OpenBTS to regiter with (for example) OpenSIPS.
